### PR TITLE
Migrating from master-slave terminology

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -25,12 +25,12 @@ import (
 type Client struct {
 	db        service.Repository
 	id        string
-	masterURL string
+	mainURL string
 	logger    log.Logger
 }
 
-//NewMaster creates client
-func NewMaster(rep service.Repository, id string, logger log.Logger) *Client {
+//NewMain creates client
+func NewMain(rep service.Repository, id string, logger log.Logger) *Client {
 	cliLog := log.With(logger, "thread", "client")
 	return &Client{
 		db:     rep,
@@ -39,14 +39,14 @@ func NewMaster(rep service.Repository, id string, logger log.Logger) *Client {
 	}
 }
 
-//NewSlave creates client
-func NewSlave(rep service.Repository, id, masterURL string, logger log.Logger) *Client {
+//NewSubordinate creates client
+func NewSubordinate(rep service.Repository, id, mainURL string, logger log.Logger) *Client {
 	cliLog := log.With(logger, "thread", "client")
 	return &Client{
 		db:        rep,
 		id:        id,
 		logger:    cliLog,
-		masterURL: masterURL,
+		mainURL: mainURL,
 	}
 }
 
@@ -61,9 +61,9 @@ type pack struct {
 //Sync perfoms synchronization
 func (c *Client) Sync(ctx context.Context) (e1 error) {
 	if c.id == "00" {
-		return c.syncMaster(ctx)
+		return c.syncMain(ctx)
 	}
-	return c.syncSlave(ctx)
+	return c.syncSubordinate(ctx)
 }
 
 //TODO recheck source usage

--- a/client/slave.go
+++ b/client/slave.go
@@ -10,8 +10,8 @@ import (
 	http1 "github.com/egorka-gh/zbazar/zsync/pkg/http"
 )
 
-//sync Slave version
-func (c *Client) syncSlave(ctx context.Context) (e1 error) {
+//sync Subordinate version
+func (c *Client) syncSubordinate(ctx context.Context) (e1 error) {
 	defer func() {
 		c.logger.Log("method", "Sync", "e1", e1)
 	}()
@@ -19,14 +19,14 @@ func (c *Client) syncSlave(ctx context.Context) (e1 error) {
 		//context canceled
 		return ctx.Err()
 	}
-	c.logger.Log("Sync", "start_pull", "source", "00", "url", c.masterURL)
+	c.logger.Log("Sync", "start_pull", "source", "00", "url", c.mainURL)
 
-	if c.masterURL == "" {
-		e1 = errors.New("Empty master URL")
+	if c.mainURL == "" {
+		e1 = errors.New("Empty main URL")
 		return e1
 	}
 
-	svc, e1 := http.New(c.masterURL, defaultHttpOptions(c.logger))
+	svc, e1 := http.New(c.mainURL, defaultHttpOptions(c.logger))
 	if e1 != nil {
 		return e1
 	}
@@ -75,7 +75,7 @@ func (c *Client) syncSlave(ctx context.Context) (e1 error) {
 			close(pulled)
 			wg.Done()
 		}()
-		_ = c.pullSyncPacks(ctx, svc, "00", c.masterURL, pulled)
+		_ = c.pullSyncPacks(ctx, svc, "00", c.mainURL, pulled)
 	}()
 
 	//waite all downloads complete & close loaded chan

--- a/cmd/service/server.go
+++ b/cmd/service/server.go
@@ -47,7 +47,7 @@ func ReadConfig() error {
 	viper.SetDefault("folder", "")          //MySQL exchange folder
 	viper.SetDefault("log", "")             //Log folder
 	viper.SetDefault("id", "")              //Instanse ID
-	viper.SetDefault("master-url", "")      //master server url (need only for slave server)
+	viper.SetDefault("main-url", "")      //main server url (need only for subordinate server)
 	viper.SetDefault("sync-interval", "10") //sinc interval (minutes)
 	viper.SetDefault("balance-hour", "2")   //hour of daily balance recalculation
 	viper.SetDefault("level-days", "1,2")   //days of monthly level recalculation (comma sepparated)
@@ -81,13 +81,13 @@ func InitServerGroup() (*group.Group, service.Repository, error) {
 	var exchangeFolder = viper.GetString("folder")
 	//var logFolder = viper.GetString("log")
 	var instanseID = viper.GetString("id")
-	var masterURL = viper.GetString("master-url")
+	var mainURL = viper.GetString("main-url")
 
 	if instanseID == "" {
 		return nil, nil, errors.New("Instanse ID not set")
 	}
-	if instanseID != "00" && masterURL == "" {
-		return nil, nil, errors.New("Master server url not set")
+	if instanseID != "00" && mainURL == "" {
+		return nil, nil, errors.New("Main server url not set")
 	}
 	if mysqlCnn == "" {
 		return nil, nil, errors.New("MySQL connection string not set")
@@ -100,7 +100,7 @@ func InitServerGroup() (*group.Group, service.Repository, error) {
 	logger.Log("MySQLConnection", mysqlCnn)
 	logger.Log("ExchangeFolder", exchangeFolder)
 	if instanseID != "00" {
-		logger.Log("MasterURL", masterURL)
+		logger.Log("MainURL", mainURL)
 	}
 	logger.Log("tracer", "none")
 	tracer = opentracinggo.GlobalTracer()
@@ -116,11 +116,11 @@ func InitServerGroup() (*group.Group, service.Repository, error) {
 	//create client
 	var cli *client.Client
 	if instanseID != "00" {
-		//start slave
-		cli = client.NewSlave(rep, instanseID, masterURL, logger)
+		//start subordinate
+		cli = client.NewSubordinate(rep, instanseID, mainURL, logger)
 	} else {
-		//start master
-		cli = client.NewMaster(rep, instanseID, logger)
+		//start main
+		cli = client.NewMain(rep, instanseID, logger)
 	}
 
 	//create service

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -33,7 +33,7 @@ func TestFixVersion(t *testing.T){
 }
 */
 
-func TestFixVersionMaster(t *testing.T) {
+func TestFixVersionMain(t *testing.T) {
 	//var mdb service.Repository
 	mrep, mdb, err := newDb("root:3411@tcp(127.0.0.1:3306)/pshdata", "D:\\Buffer\\zexch")
 	if err != nil {
@@ -97,26 +97,26 @@ func TestFixVersionMaster(t *testing.T) {
 
 }
 
-func TestSyncSlave(t *testing.T) {
+func TestSyncSubordinate(t *testing.T) {
 	mrep, mdb, err := newDb("root:3411@tcp(127.0.0.1:3306)/pshdata", "D:\\Buffer\\zexch")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer mdb.Close()
-	srep, sdb, err := newDb("root:3411@tcp(127.0.0.1:3306)/zslave", "D:\\Buffer\\zexch")
+	srep, sdb, err := newDb("root:3411@tcp(127.0.0.1:3306)/zsubordinate", "D:\\Buffer\\zexch")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer sdb.Close()
 
-	//get table versions in slave
+	//get table versions in subordinate
 	ver0, err := srep.ListVersion(context.Background(), "00")
 	if err != nil {
 		t.Error(err)
 	}
 	t.Log(ver0)
 
-	//generate sync packs in master
+	//generate sync packs in main
 	packList := make([]service.VersionPack, 0, len(ver0))
 	for _, v0 := range ver0 {
 		var fileName = "00_" + v0.Table + "_" + strconv.FormatInt(int64(v0.Version), 10) + ".dat"
@@ -128,7 +128,7 @@ func TestSyncSlave(t *testing.T) {
 	}
 	t.Log(packList)
 
-	//apply packs in slave
+	//apply packs in subordinate
 	for _, p := range packList {
 		if p.Pack == "" {
 			t.Log("Version not changed or error in CreatePack", p)
@@ -139,7 +139,7 @@ func TestSyncSlave(t *testing.T) {
 		}
 	}
 
-	//check versions vs master
+	//check versions vs main
 	ver0, err = srep.ListVersion(context.Background(), "00")
 	if err != nil {
 		t.Error(err)
@@ -157,7 +157,7 @@ func TestSyncSlave(t *testing.T) {
 			if v0.Table == v.Table {
 				found = true
 				if v0.Version != v.Version {
-					t.Error(v0.Table, "Version not changed. Slave version ", v0.Version, ". Master version ", v.Version)
+					t.Error(v0.Table, "Version not changed. Subordinate version ", v0.Version, ". Main version ", v.Version)
 				}
 			}
 		}
@@ -168,9 +168,9 @@ func TestSyncSlave(t *testing.T) {
 
 }
 
-func TestFixVersionSlave(t *testing.T) {
+func TestFixVersionSubordinate(t *testing.T) {
 	//var mdb service.Repository
-	mrep, mdb, err := newDb("root:3411@tcp(127.0.0.1:3306)/zslave", "D:\\Buffer\\zexch")
+	mrep, mdb, err := newDb("root:3411@tcp(127.0.0.1:3306)/zsubordinate", "D:\\Buffer\\zexch")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,26 +212,26 @@ func TestFixVersionSlave(t *testing.T) {
 
 }
 
-func TestSyncMaster(t *testing.T) {
+func TestSyncMain(t *testing.T) {
 	mrep, mdb, err := newDb("root:3411@tcp(127.0.0.1:3306)/pshdata", "D:\\Buffer\\zexch")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer mdb.Close()
-	srep, sdb, err := newDb("root:3411@tcp(127.0.0.1:3306)/zslave", "D:\\Buffer\\zexch")
+	srep, sdb, err := newDb("root:3411@tcp(127.0.0.1:3306)/zsubordinate", "D:\\Buffer\\zexch")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer sdb.Close()
 
-	//get table versions in  master
+	//get table versions in  main
 	ver0, err := mrep.ListVersion(context.Background(), "zs")
 	if err != nil {
 		t.Error(err)
 	}
 	t.Log(ver0)
 
-	//generate sync packs in slave
+	//generate sync packs in subordinate
 	packList := make([]service.VersionPack, 0, len(ver0))
 	for _, v0 := range ver0 {
 		var fileName = "zs_" + v0.Table + "_" + strconv.FormatInt(int64(v0.Version), 10) + ".dat"
@@ -243,7 +243,7 @@ func TestSyncMaster(t *testing.T) {
 	}
 	t.Log(packList)
 
-	//apply packs in master
+	//apply packs in main
 	for _, p := range packList {
 		if p.Pack == "" {
 			t.Log("Version not changed or error in CreatePack", p)
@@ -254,7 +254,7 @@ func TestSyncMaster(t *testing.T) {
 		}
 	}
 
-	//check versions vs slave
+	//check versions vs subordinate
 	ver0, err = mrep.ListVersion(context.Background(), "zs")
 	if err != nil {
 		t.Error(err)
@@ -272,7 +272,7 @@ func TestSyncMaster(t *testing.T) {
 			if v0.Table == v.Table {
 				found = true
 				if v0.Version != v.Version {
-					t.Error(v0.Table, "Version not changed. Master version ", v0.Version, ". Slave version ", v.Version)
+					t.Error(v0.Table, "Version not changed. Main version ", v0.Version, ". Subordinate version ", v.Version)
 				}
 			}
 		}

--- a/pkg/test/service_test.go
+++ b/pkg/test/service_test.go
@@ -47,7 +47,7 @@ func initLoger(toFile bool) {
 
 }
 
-func TestMoveVersionMaster(t *testing.T) {
+func TestMoveVersionMain(t *testing.T) {
 	var exchFolder = "D:\\Buffer\\zexch"
 	initLoger(true)
 
@@ -69,7 +69,7 @@ func TestMoveVersionMaster(t *testing.T) {
 	t.Log(ver0)
 
 	//some db activity
-	err = updateMaster(mdb)
+	err = updateMain(mdb)
 	if err != nil {
 		t.Error(err)
 	}
@@ -97,12 +97,12 @@ func TestMoveVersionMaster(t *testing.T) {
 
 }
 
-func TestMoveVersionSlave(t *testing.T) {
+func TestMoveVersionSubordinate(t *testing.T) {
 	var exchFolder = "D:\\Buffer\\zexch"
 	initLoger(true)
 
 	var mrep service.Repository
-	mrep, mdb, err := NewDb("root:3411@tcp(127.0.0.1:3306)/zslave", exchFolder)
+	mrep, mdb, err := NewDb("root:3411@tcp(127.0.0.1:3306)/zsubordinate", exchFolder)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestMoveVersionSlave(t *testing.T) {
 	t.Log(ver0)
 
 	//some db activity
-	err = updateSlave(mdb)
+	err = updateSubordinate(mdb)
 	if err != nil {
 		t.Error(err)
 	}
@@ -207,7 +207,7 @@ func TestAddActivity(t *testing.T) {
 	initLoger(true)
 
 	var mrep service.Repository
-	mrep, mdb, err := NewDb("root:3411@tcp(127.0.0.1:3306)/zslave?parseTime=true", exchFolder)
+	mrep, mdb, err := NewDb("root:3411@tcp(127.0.0.1:3306)/zsubordinate?parseTime=true", exchFolder)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.